### PR TITLE
CONFSERVER-55442 remove borked version of collectd

### DIFF
--- a/templates/ConfluenceDataCenter.template
+++ b/templates/ConfluenceDataCenter.template
@@ -533,7 +533,7 @@ Resources:
             !If
               - DoCollectd
               - yum:
-                  collectd: [5.7.1]
+                  collectd: []
                   collectd-java: []
                   collectd-generic-jmx: []
                   collectd-rrdtool: []
@@ -748,7 +748,7 @@ Resources:
             !If
               - DoCollectd
               - yum:
-                  collectd: [5.7.1]
+                  collectd: []
                   collectd-java: []
                   collectd-generic-jmx: []
                   collectd-rrdtool: []


### PR DESCRIPTION
Customers cannot use Quickstart to create Confluence stacks now because collectd 5.7.1 is no longer available in AWS repo. This change will ask Confluence to install the latest version of collectd.