### PR TITLE
DCD-534: Switch default collaborative editing mode to synchrony-local

### DIFF
--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -300,7 +300,7 @@ Parameters:
       - z1d.6xlarge
       - z1d.12xlarge
     ConstraintDescription: Must be an EC2 instance type from the selection list
-    Description: Instance type for the cluster application nodes (note - for "synchrony-local" collaborative editing you must chose an instance size with over 5 GB RAM).
+    Description: Instance type for the cluster application nodes (note - for "synchrony-local" collaborative editing you must choose an instance size with over 5 GB RAM).
     Type: String
   ClusterNodeMax:
     Description: Maximum number of nodes in the cluster.
@@ -320,7 +320,7 @@ Parameters:
       - none
       - synchrony-local
       - synchrony-separate-nodes
-    Description: Collaborative Editing can be off, run locallly on the Confluence nodes (requires Confluence version 6.12+ and 1 GB heap free for Synchrony), or run on a separately autoscaled group of nodes.
+    Description: Collaborative Editing can be off, run locally on the Confluence nodes (requires Confluence version 6.12+ and 1 GB heap free for Synchrony), or run on a separately autoscaled group of nodes.
     Type: String
   ConfluenceVersion:
     Default: '6.13.5'
@@ -411,7 +411,7 @@ Parameters:
     Type: String
   DBMaxStatements:
     Default: 0
-    Description: "The size of c3p0's global PreparedStatement cache. It controls the total number of Statements cached, for all Connections. If set, it should be a fairly large number, as each pooled Connection requires its own, distinct flock of cached statements."
+    Description: "The size of c3p0's global PreparedStatement cache. It controls the total number of statements cached, for all connections. If set, it should be a fairly large number, as each pooled Connection requires its own, distinct flock of cached statements."
     Type: String
   DBValidate:
     Default: false
@@ -459,11 +459,11 @@ Parameters:
   DeploymentAutomationKeyName:
     Default: ""
     Type: String
-    Description: (Optional) Named KeyPair name to use with this repository. The key should be imported into the SSM parameter store.
+    Description: (Optional) Named KeyPair name to use with this repository. The key should be imported into the AWS Systems Manager parameter store.
   HostedZone:
     Default: ''
-    ConstraintDescription: Must be the name of an existing Route53 Hosted Zone.
-    Description: (Optional) The domain name of the Route53 PRIVATE Hosted Zone in which to create cnames.
+    ConstraintDescription: Must be the name of an existing Amazon Route 53 Hosted Zone.
+    Description: (Optional) The domain name of the Amazon Route 53 PRIVATE Hosted Zone in which to create cnames.
     Type: String
   InternetFacingLoadBalancer:
     Default: true
@@ -612,7 +612,7 @@ Parameters:
     Type: String
   TomcatConnectionTimeout:
     Default: 20000
-    Description: The number of milliseconds this Connector will wait, after accepting a connection, for the request URI line to be presented.
+    Description: The number of milliseconds this connector will wait, after accepting a connection, for the request URI line to be presented.
     Type: String
   TomcatContextPath:
     Default: ''
@@ -629,7 +629,7 @@ Parameters:
     Type: String
   TomcatMaxThreads:
     Default: 48
-    Description: The maximum number of request processing threads to be created by this Connector, which therefore determines the maximum number of simultaneous requests that can be handled.
+    Description: The maximum number of request processing threads to be created by this connector, which therefore determines the maximum number of simultaneous requests that can be handled.
     Type: String
   TomcatMinSpareThreads:
     Default: 10

--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -197,7 +197,7 @@ Metadata:
 Parameters:
   CatalinaOpts:
     Default: ''
-    Description: Pass in any additional JVM options to tune Catalina Tomcat.
+    Description: Java options that are passed to the Java virtual machine (JVM) that runs Confluence.
     Type: String
   CidrBlock:
     AllowedPattern: '(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})'
@@ -473,11 +473,11 @@ Parameters:
     Type: String
   JvmHeapOverride:
     Default: ''
-    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g.
+    Description: The heap size to use, in MB (e.g., 1024m) or GB (e.g., 1g), to override the default amount of memory to allocate to the JVM for your instance type.
     Type: String
   JvmHeapOverrideSynchrony:
     Default: ''
-    Description: Override the default amount of memory to allocate to the JVM for Synchrony, for your instance type - set size in meg or gig e.g. 1024m or 1g.
+    Description: The heap size to use, in MiB (e.g., 1024m) or GiB (e.g., 1g), to override the default amount of memory to allocate to the JVM for Synchrony.
     Type: String
   KeyPairName:
     Default: ''

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -306,7 +306,7 @@ Parameters:
       - z1d.6xlarge
       - z1d.12xlarge
     ConstraintDescription: Must be an EC2 instance type from the selection list
-    Description: Instance type for the cluster application nodes (note - for "synchrony-local" collaborative editing you must chose an instance size with over 5 GB RAM).
+    Description: Instance type for the cluster application nodes (note - for "synchrony-local" collaborative editing you must choose an instance size with over 5 GB RAM).
     Type: String
   ClusterNodeMax:
     Description: Maximum number of nodes in the cluster.
@@ -326,7 +326,7 @@ Parameters:
       - none
       - synchrony-local
       - synchrony-separate-nodes
-    Description: Collaborative Editing can be off, run locallly on the Confluence nodes (requires Confluence version 6.12+ and 1 GB heap free for Synchrony), or run on a separately autoscaled group of nodes.
+    Description: Collaborative Editing can be off, run locally on the Confluence nodes (requires Confluence version 6.12+ and 1 GB heap free for Synchrony), or run on a separately autoscaled group of nodes.
     Type: String
   ConfluenceVersion:
     Default: '6.13.5'
@@ -417,7 +417,7 @@ Parameters:
     Type: String
   DBMaxStatements:
     Default: 0
-    Description: "The size of c3p0's global PreparedStatement cache. It controls the total number of Statements cached, for all Connections. If set, it should be a fairly large number, as each pooled Connection requires its own, distinct flock of cached statements."
+    Description: "The size of c3p0's global PreparedStatement cache. It controls the total number of statements cached, for all connections. If set, it should be a fairly large number, as each pooled Connection requires its own, distinct flock of cached statements."
     Type: String
   DBValidate:
     Default: false
@@ -465,11 +465,11 @@ Parameters:
   DeploymentAutomationKeyName:
     Default: ""
     Type: String
-    Description: (Optional) Named KeyPair name to use with this repository. The key should be imported into the SSM parameter store.
+    Description: (Optional) Named KeyPair name to use with this repository. The key should be imported into the AWS Systems Manager parameter store.
   HostedZone:
     Default: ''
-    ConstraintDescription: Must be the name of an existing Route53 Hosted Zone.
-    Description: (Optional) The domain name of the Route53 PRIVATE Hosted Zone in which to create cnames.
+    ConstraintDescription: Must be the name of an existing Amazon Route 53 Hosted Zone.
+    Description: (Optional) The domain name of the Amazon Route 53 PRIVATE Hosted Zone in which to create cnames.
     Type: String
   InternetFacingLoadBalancer:
     Default: true
@@ -619,7 +619,7 @@ Parameters:
     Type: String
   TomcatConnectionTimeout:
     Default: 20000
-    Description: The number of milliseconds this Connector will wait, after accepting a connection, for the request URI line to be presented.
+    Description: The number of milliseconds this connector will wait, after accepting a connection, for the request URI line to be presented.
     Type: String
   TomcatContextPath:
     Default: ''
@@ -636,7 +636,7 @@ Parameters:
     Type: String
   TomcatMaxThreads:
     Default: 48
-    Description: The maximum number of request processing threads to be created by this Connector, which therefore determines the maximum number of simultaneous requests that can be handled.
+    Description: The maximum number of request processing threads to be created by this connector, which therefore determines the maximum number of simultaneous requests that can be handled.
     Type: String
   TomcatMinSpareThreads:
     Default: 10

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -203,7 +203,7 @@ Parameters:
     Type: String
   CatalinaOpts:
     Default: ''
-    Description: Pass in any additional JVM options to tune Catalina Tomcat.
+    Description: Java options that are passed to the Java virtual machine (JVM) that runs Confluence.
     Type: String
   CidrBlock:
     AllowedPattern: '(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})'
@@ -479,11 +479,11 @@ Parameters:
     Type: String
   JvmHeapOverride:
     Default: ''
-    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig; e.g., 1024m or 1g.
+    Description: The heap size to use, in MB (e.g., 1024m) or GB (e.g., 1g), to override the default amount of memory to allocate to the JVM for your instance type.
     Type: String
   JvmHeapOverrideSynchrony:
     Default: ''
-    Description: Override the default amount of memory to allocate to the JVM for Synchrony, for your instance type - set size in meg or gig; e.g., 1024m or 1g.
+    Description: The heap size to use, in MB (e.g., 1024m) or GB (e.g., 1g), to override the default amount of memory to allocate to the JVM for your instance type.
     Type: String
   KeyPairName:
     Default: ''


### PR DESCRIPTION
The local managed Synchrony is the preferred setup and we should keep synchrony-separate-nodes only for backward compatibility purposes. If that is the case, we should switch the default to synchrony-local and include a note in the documentation that if you are running Confluence prior 6.12 you need to explicitly select synchrony-separate-nodes.

Link to the recommendation:

https://confluence.atlassian.com/doc/possible-confluence-and-synchrony-configurations-958779064.html#PossibleConfluenceandSynchronyConfigurations-PossibleconfigurationsforConfluenceDataCenter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
