### PR TITLE
DCD-594 & DCD-597: Add default taskcat param file

### DIFF
--- a/ci/params/default/quickstart-confluence-default.json
+++ b/ci/params/default/quickstart-confluence-default.json
@@ -1,9 +1,5 @@
 [
   {
-    "ParameterKey": "AvailabilityZones",
-    "ParameterValue": "$[taskcat_genaz_2]"
-  },
-  {
     "ParameterKey": "DBMasterUserPassword",
     "ParameterValue": "f925dO1ry_"
   },
@@ -24,12 +20,8 @@
     "ParameterValue": "Provisioned IOPS"
   },
   {
-    "ParameterKey": "CustomDnsName",
-    "ParameterValue": "qs-conf-ci.awsqs.com"
-  },
-  {
     "ParameterKey": "CidrBlock",
-    "ParameterValue": "10.0.0.0/16"
+    "ParameterValue": "0.0.0.0/0"
   },
   {
     "ParameterKey": "QSS3BucketName",

--- a/ci/params/default/taskcat.yml
+++ b/ci/params/default/taskcat.yml
@@ -1,0 +1,24 @@
+global:
+  marketplace-ami: false
+  owner: quickstart-eng@amazon.com
+  qsname: quickstart-atlassian-confluence
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-west-1
+    - us-west-2
+  reporting: true
+
+tests:
+  confluence:
+    parameter_input: params/default/quickstart-confluence-default.json
+    template_file: quickstart-confluence-master.template.yaml
+    regions:
+     - us-east-1

--- a/ci/quickstart-confluence-aurora.json
+++ b/ci/quickstart-confluence-aurora.json
@@ -1,11 +1,11 @@
 [
   {
     "ParameterKey": "DBMasterUserPassword",
-    "ParameterValue": "$[taskcat_genpass_8S]"
+    "ParameterValue": "f925dO1ry_"
   },
   {
     "ParameterKey": "DBPassword",
-    "ParameterValue": "$[taskcat_genpass_8S]"
+    "ParameterValue": "f925dO1ry_"
   },
   {
     "ParameterKey": "QSS3BucketName",


### PR DESCRIPTION
DCD-594: Add default taskcat param file
DCD-597: Fix duplicate db resource & Sync with upstream

*Description of changes:*
* Add default param file for `taskcat`
* Needed workaround for `taskcat` autogenerated passwords (it contained `@` and other forbidden characters)
* Update ASI submodule to include https://github.com/aws-quickstart/quickstart-atlassian-services/pull/14

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
