### PR TITLE
 DCD-954: Add bastion to EC2 security group #70 

### DIFF
--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -517,8 +517,8 @@ Parameters:
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances. 
-    Type: List<AWS::EC2::Keypair>
+    Description: The EC2 Key Pair to allow SSH access to the instances.
+    Type: AWS::EC2::KeyPair::KeyName
     Default: ''
   MailEnabled:
     AllowedValues:

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -1787,6 +1787,14 @@ Resources:
           ToPort: 8091
           CidrIp: !Ref CidrBlock
         - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp:
+            !Sub
+              - "${BastionIp}/32"
+              - BastionIp:
+                  Fn::ImportValue: !Sub '${ExportPrefix}BastionPrivIp'
+        - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
           CidrIp:


### PR DESCRIPTION
Imports the private IP of the bastion host from the ASI so that when CidrBlock is set the Bastion can still SSH to the webserver.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.