### PR TITLE
 DCD-948: Make Bastion host provisioning optional

### DIFF
--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -392,8 +392,8 @@ Parameters:
     AllowedPattern: >-
       ^(?=^.{8,255}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?!.*[@/"']).*$
     ConstraintDescription: >-
-      Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
-    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol."
+      Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &
+    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &"
     MinLength: 8
     MaxLength: 128
     NoEcho: true
@@ -408,8 +408,8 @@ Parameters:
     Type: String
   DBPassword:
     AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
-    ConstraintDescription: "Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol"
-    Description: "Password for the user account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol."
+    ConstraintDescription: 'Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &'
+    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &"
     MinLength: 8
     MaxLength: 128
     NoEcho: true

--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -392,8 +392,8 @@ Parameters:
     AllowedPattern: >-
       ^(?=^.{8,255}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?!.*[@/"']).*$
     ConstraintDescription: >-
-      Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &
-    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &"
+      Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ + % &
+    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ + % &"
     MinLength: 8
     MaxLength: 128
     NoEcho: true

--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -409,7 +409,7 @@ Parameters:
   DBPassword:
     AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
     ConstraintDescription: 'Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &'
-    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &"
+    Description: "Database password used by Confluence. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &"
     MinLength: 8
     MaxLength: 128
     NoEcho: true

--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -39,12 +39,16 @@ Metadata:
           - DBStorageEncrypted
           - DBStorageType
       - Label:
+          default: Bastion host provisioning
+        Parameters:
+          - BastionHostRequired
+          - KeyPairName
+      - Label:
           default: Networking
         Parameters:
           - AvailabilityZones
           - CidrBlock
           - InternetFacingLoadBalancer
-          - KeyPairName
           - SSLCertificateARN
       - Label:
           default: DNS
@@ -160,6 +164,8 @@ Metadata:
         default: Confluence Heap Size Override
       JvmHeapOverrideSynchrony:
         default: Synchrony Heap Size Override
+      BastionHostRequired:
+        default: Deploy Bastion host
       KeyPairName:
         default: SSH Key Pair Name
       MailEnabled:
@@ -518,10 +524,17 @@ Parameters:
     Default: ''
     Description: The heap size to use, in MiB (e.g., 1024m) or GiB (e.g., 1g), to override the default amount of memory to allocate to the JVM for Synchrony.
     Type: String
+  BastionHostRequired:
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Whether to provision a Bastion host instance. If 'true', then you need to provide an EC2 Key Pair (otherwise, you won't be able to use the Bastion host to access Confluence instances).
+    Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances.
-    Type: AWS::EC2::KeyPair::KeyName
+    Description: Public/private EC2 Key Pairs to allow you to securely access the Bastion host
+    Type: String
     Default: ''
   MailEnabled:
     AllowedValues:
@@ -717,6 +730,11 @@ Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
     - us-gov-west-1
+  KeyProvided:
+    !Not [!Equals [!Ref KeyPairName, '']]
+  ProvisionBastion: !And
+    - !Equals [!Ref BastionHostRequired, true]
+    - !Condition KeyProvided
 
 Resources:
   VPCStack:
@@ -735,6 +753,8 @@ Resources:
           - !Ref 'AvailabilityZones'
         ExportPrefix: !Ref 'ExportPrefix'
         KeyPairName: !Ref 'KeyPairName'
+        BastionHostRequired: !Ref 'BastionHostRequired'
+
 
   ConfluenceStack:
     DependsOn: VPCStack
@@ -805,6 +825,7 @@ Resources:
         TomcatRedirectPort: !Ref 'TomcatRedirectPort'
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        BastionHostRequired: !Ref 'BastionHostRequired'
 
 Outputs:
   ServiceURL:
@@ -814,6 +835,7 @@ Outputs:
     Description: The Load Balancer URL.
     Value: !GetAtt 'ConfluenceStack.Outputs.LoadBalancerURL'
   BastionIP:
+    Condition: ProvisionBastion
     Description: Bastion node IP (use as a jumpbox to connect to the nodes).
     Value: !GetAtt 'VPCStack.Outputs.BastionPubIp'
   SGname:

--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -400,10 +400,10 @@ Parameters:
     Type: String
   DBMultiAZ:
     Description: When DBEngine is 'PostgreSQL', this will determine whether to provision a multi-AZ RDS instance. When DBEngine is 'Amazon Aurora PostgreSQL', this will determine whether to provision a single or a multiple-node Amazon Aurora cluster.
-    Default: true
+    Default: "true"
     AllowedValues:
-      - true
-      - false
+      - "true"
+      - "false"
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
   DBPassword:
@@ -417,25 +417,28 @@ Parameters:
   DBPoolMaxSize:
     Default: 60
     Description: The maximum number of database connections that can be opened at any time. See https://confluence.atlassian.com/doc/performance-tuning-130289.html for reference on tuning database parameters.
-    Type: String
+    Type: Number
   DBPoolMinSize:
     Default: 20
     Description: The minimum number of idle database connections that are kept open at any time.
-    Type: String
+    Type: Number
   DBTimeout:
     Default: 30
     Description: Number of seconds that Connections in excess of minPoolSize should be permitted to remain idle in the pool before being culled.
-    Type: String
+    Type: Number
   DBIdleTestPeriod:
     Default: 100
     Description: If greater than 0, this is the frequency (in seconds) that c3po will test all idle, pooled but unchecked-out connections.
-    Type: String
+    Type: Number
   DBMaxStatements:
     Default: 0
     Description: "The size of c3p0's global PreparedStatement cache. It controls the total number of statements cached, for all connections. If set, it should be a fairly large number, as each pooled Connection requires its own, distinct flock of cached statements."
-    Type: String
+    Type: Number
   DBValidate:
-    Default: false
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
     Description: If true, a connection test will be performed at every connection checkout to verify that the connection is valid.
     Type: String
   DBPreferredTestQuery:
@@ -445,16 +448,16 @@ Parameters:
   DBAcquireIncrement:
     Default: 1
     Description: Determines how many connections at a time c3p0 will try to acquire when the pool is exhausted.
-    Type: String
+    Type: Number
   DBStorage:
     Default: 200
     Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144. Not used for Amazon Aurora.
     Type: Number
   DBStorageEncrypted:
-    Default: false
+    Default: "false"
     AllowedValues:
-      - true
-      - false
+      - "true"
+      - "false"
     Description: Whether or not to encrypt the database.
     Type: String
   DBStorageType:
@@ -502,8 +505,8 @@ Parameters:
     Description: (Optional) The domain name of the Amazon Route 53 PRIVATE Hosted Zone in which to create cnames.
     Type: String
   InternetFacingLoadBalancer:
-    Default: true
-    AllowedValues: [true, false]
+    Default: "true"
+    AllowedValues: ["true", "false"]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String
@@ -522,10 +525,10 @@ Parameters:
     Default: ''
   MailEnabled:
     AllowedValues:
-      - true
-      - false
+      - "true"
+      - "false"
     ConstraintDescription: Must be 'true' or 'false'.
-    Default: true
+    Default: "true"
     Description: Enable mail processing and sending.
     Type: String
   SubDomainName:
@@ -645,11 +648,11 @@ Parameters:
   TomcatAcceptCount:
     Default: 10
     Description: The maximum queue length for incoming connection requests when all possible request processing threads are in use.
-    Type: String
+    Type: Number
   TomcatConnectionTimeout:
     Default: 20000
     Description: The number of milliseconds this connector will wait, after accepting a connection, for the request URI line to be presented.
-    Type: String
+    Type: Number
   TomcatContextPath:
     Default: ''
     AllowedPattern: '^(\/[A-z_\-0-9\.]+)?$'
@@ -658,19 +661,22 @@ Parameters:
   TomcatDefaultConnectorPort:
     Default: 8080
     Description: The port on which to serve the application.
-    Type: String
+    Type: Number
   TomcatEnableLookups:
-    Default: false
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
     Description: Set to true if you want calls to request.getRemoteHost() to perform DNS lookups in order to return the actual host name of the remote client.
     Type: String
   TomcatMaxThreads:
     Default: 48
     Description: The maximum number of request processing threads to be created by this connector, which therefore determines the maximum number of simultaneous requests that can be handled.
-    Type: String
+    Type: Number
   TomcatMinSpareThreads:
     Default: 10
     Description: The minimum number of threads always kept running.
-    Type: String
+    Type: Number
   TomcatProtocol:
     Default: 'HTTP/1.1'
     Description: Sets the protocol to handle incoming traffic.
@@ -678,7 +684,7 @@ Parameters:
   TomcatRedirectPort:
     Default: 8443
     Description: The port number for Catalina to use when automatically redirecting a non-SSL connector actioning a redirect to a SSL URI.
-    Type: String
+    Type: Number
 
   # VPC parameters
   AvailabilityZones:

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -1117,6 +1117,7 @@ Resources:
             Statement:
               - Action:
                   - 'ssm:PutParameter'
+                  - 'ssm:DeleteParameter'
                 Effect: Allow
                 Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha"
   ConfluenceClusterNodeInstanceProfile:

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -1111,6 +1111,14 @@ Resources:
               - Action: ['s3:Get*']
                 Effect: Allow
                 Resource: [!Sub 'arn:${AWS::Partition}:s3:::/atlassian-software/snapshots/confluence/*']
+        - PolicyName: SSMParameterPutAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - 'ssm:PutParameter'
+                Effect: Allow
+                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha"
   ConfluenceClusterNodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -1149,6 +1157,7 @@ Resources:
     DependsOn:
       - EFSMountAz1
       - EFSMountAz2
+      - AnsibleRepoPinSHA
     Metadata:
       AWS::CloudFormation::Init:
         config:
@@ -1228,12 +1237,13 @@ Resources:
                 #!/bin/bash
                 key_location=/root/.ssh/deployment_repo_key
                 key_name="${DeploymentAutomationKeyName}"
+                ssm_pin=/${AWS::StackName}/pinned-ansible-sha
 
-                yum install -y git
+                yum install -y git awscli jq
+
                 if [[ ! -z "$key_name" ]]; then
                     # Ensure awscli is up to date
-                    yum install -y awscli jq
-                    key_val=$(aws --region=${AWS::Region} ssm get-parameters --names "$key_name" --with-decryption | jq --raw-output '.Parameters[0] .Value')
+                    key_val=$(aws --region=${AWS::Region} ssm get-parameters --names "$key_name" --with-decryption | jq --raw-output '.Parameters[0].Value')
                     echo -e "$key_val" > $key_location
                     chmod 600 $key_location
                     export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i $key_location"
@@ -1241,7 +1251,21 @@ Resources:
                     export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
                 fi
 
+                ### Ansible repo pinning ###
+                pinned_commit_id=$(aws --region=${AWS::Region} ssm get-parameters --names "$ssm_pin" | jq --raw-output '.Parameters[0].Value')
+
                 git clone "${DeploymentAutomationRepository}" -b "${DeploymentAutomationBranch}" /opt/atlassian/dc-deployments-automation/
+                cd /opt/atlassian/dc-deployments-automation/
+
+                if [[ "$pinned_commit_id" == "latest" || -z "$pinned_commit_id" ]]; then
+                  head_id=$(git rev-parse HEAD)
+                  echo "SSM param [$ssm_pin] has been set to 'latest' - Using the HEAD SHA [$head_id] to build cluster [${AWS::StackName}]"
+                  echo "Updating SSM param [$ssm_pin] with current HEAD SHA: [$head_id]"
+                  aws --region=${AWS::Region} ssm put-parameter --name "$ssm_pin" --value "$head_id" --overwrite --type String
+                else
+                  echo "Ansible repo has been pinned, checking out commit: [$pinned_commit_id]"
+                  git checkout -b "pinned-ansible-sha-$pinned_commit_id" "$pinned_commit_id"
+                fi
               mode: "000750"
               owner: root
               group: root
@@ -1370,6 +1394,7 @@ Resources:
     DependsOn:
       - EFSMountAz1
       - EFSMountAz2
+      - AnsibleRepoPinSHA
     Metadata:
       AWS::CloudFormation::Init:
         config:
@@ -1430,12 +1455,13 @@ Resources:
                 #!/bin/bash
                 key_location=/root/.ssh/deployment_repo_key
                 key_name="${DeploymentAutomationKeyName}"
+                ssm_pin=/${AWS::StackName}/pinned-ansible-sha
 
-                yum install -y git
+                yum install -y git awscli jq
+
                 if [[ ! -z "$key_name" ]]; then
                     # Ensure awscli is up to date
-                    yum install -y awscli jq
-                    key_val=$(aws --region=${AWS::Region} ssm get-parameters --names "$key_name" --with-decryption | jq --raw-output '.Parameters[0] .Value')
+                    key_val=$(aws --region=${AWS::Region} ssm get-parameters --names "$key_name" --with-decryption | jq --raw-output '.Parameters[0].Value')
                     echo -e "$key_val" > $key_location
                     chmod 600 $key_location
                     export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i $key_location"
@@ -1443,7 +1469,21 @@ Resources:
                     export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
                 fi
 
+                ### Ansible repo pinning ###
+                pinned_commit_id=$(aws --region=${AWS::Region} ssm get-parameters --names "$ssm_pin" | jq --raw-output '.Parameters[0].Value')
+
                 git clone "${DeploymentAutomationRepository}" -b "${DeploymentAutomationBranch}" /opt/atlassian/dc-deployments-automation/
+                cd /opt/atlassian/dc-deployments-automation/
+
+                if [[ "$pinned_commit_id" == "latest" || -z "$pinned_commit_id" ]]; then
+                  head_id=$(git rev-parse HEAD)
+                  echo "SSM param [$ssm_pin] has been set to 'latest' - Using the HEAD SHA [$head_id] to build cluster [${AWS::StackName}]"
+                  echo "Updating SSM param [$ssm_pin] with current HEAD SHA: [$head_id]"
+                  aws --region=${AWS::Region} ssm put-parameter --name "$ssm_pin" --value "$head_id" --overwrite --type String
+                else
+                  echo "Ansible repo has been pinned, checking out commit: [$pinned_commit_id]"
+                  git checkout -b "pinned-ansible-sha-$pinned_commit_id" "$pinned_commit_id"
+                fi
               mode: "000750"
               owner: root
               group: root
@@ -1849,6 +1889,15 @@ Resources:
       FromPort: -1
       ToPort: -1
       SourceSecurityGroupId: !Ref SecurityGroup
+  AnsibleRepoPinSHA:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: "The dc-deployments-automation commit SHA that all nodes in the cluster will use"
+      Name: !Sub "/${AWS::StackName}/pinned-ansible-sha"
+      Type: String
+      AllowedPattern: '^(latest)|([0-9a-f]{5,40})$'
+      Value: "latest"
+
 # Optional: CloudWatch dashboard to be created when CloudWatch is enabled
   CloudWatchDashboard:
     DependsOn:

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -38,11 +38,15 @@ Metadata:
           - DBStorageEncrypted
           - DBStorageType
       - Label:
+          default: Bastion host utilization
+        Parameters:
+          - BastionHostRequired
+          - KeyPairName
+      - Label:
           default: Networking
         Parameters:
           - CidrBlock
           - InternetFacingLoadBalancer
-          - KeyPairName
           - SSLCertificateARN
       - Label:
           default: DNS
@@ -162,6 +166,8 @@ Metadata:
         default: Confluence Heap Size Override
       JvmHeapOverrideSynchrony:
         default: Synchrony Heap Size Override
+      BastionHostRequired:
+        default: Use Bastion host
       KeyPairName:
         default: SSH Key Pair Name
       MailEnabled:
@@ -524,10 +530,17 @@ Parameters:
     Default: ''
     Description: The heap size to use, in MiB (e.g., 1024m) or GiB (e.g., 1g), to override the default amount of memory to allocate to the JVM for Synchrony.
     Type: String
+  BastionHostRequired:
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Whether to grant access to Confluence EC2 instances through the ASI's Bastion host (if it exists). If 'true', remember to provide an EC2 Key Pair. If your ASI does not have a Bastion host, set this to 'false'.
+    Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances.
-    Type: AWS::EC2::KeyPair::KeyName
+    Description: Public/private EC2 Key Pairs to allow you to securely access the Bastion host
+    Type: String
     Default: ''
   MailEnabled:
     AllowedValues:
@@ -744,6 +757,9 @@ Conditions:
     !Equals [!Ref DBEngine, "Amazon Aurora PostgreSQL"]
   DBEnginePostgres:
     !Equals [!Ref DBEngine, "PostgreSQL"]
+  UseBastionHost: !And
+    - !Equals [!Ref BastionHostRequired, true]
+    - !Condition KeyProvided
 Mappings:
   AWSInstanceType2Arch:
     c4.large:
@@ -1298,7 +1314,7 @@ Resources:
       KeyName: !If
         - KeyProvided
         - !Ref KeyPairName
-        - Fn::ImportValue: !Sub "${ExportPrefix}DefaultKey"
+        - Ref: AWS::NoValue
       IamInstanceProfile: !Ref ConfluenceClusterNodeInstanceProfile
       ImageId:
         !FindInMap
@@ -1831,14 +1847,17 @@ Resources:
           FromPort: 8091
           ToPort: 8091
           CidrIp: !Ref CidrBlock
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp:
-            !Sub
+        - !If
+          - UseBastionHost
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp:
+              !Sub
               - "${BastionIp}/32"
               - BastionIp:
                   Fn::ImportValue: !Sub '${ExportPrefix}BastionPrivIp'
+          - Ref: AWS::NoValue
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -404,8 +404,8 @@ Parameters:
     AllowedPattern: >-
       ^(?=^.{8,255}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?!.*[@/"']).*$
     ConstraintDescription: >-
-      Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
-    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol."
+      Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &
+    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &"
     MinLength: 8
     MaxLength: 128
     NoEcho: true
@@ -420,8 +420,8 @@ Parameters:
     Type: String
   DBPassword:
     AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
-    ConstraintDescription: "Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol"
-    Description: "Password for the user account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol."
+    ConstraintDescription: 'Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &'
+    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &"
     MinLength: 8
     MaxLength: 128
     NoEcho: true

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -421,7 +421,7 @@ Parameters:
   DBPassword:
     AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
     ConstraintDescription: 'Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &'
-    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &"
+    Description: "Database password used by Confluence. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &"
     MinLength: 8
     MaxLength: 128
     NoEcho: true

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -1117,7 +1117,6 @@ Resources:
             Statement:
               - Action:
                   - 'ssm:PutParameter'
-                  - 'ssm:DeleteParameter'
                 Effect: Allow
                 Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha"
   ConfluenceClusterNodeInstanceProfile:

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -404,8 +404,8 @@ Parameters:
     AllowedPattern: >-
       ^(?=^.{8,255}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?!.*[@/"']).*$
     ConstraintDescription: >-
-      Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &
-    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &"
+      Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ + % &
+    Description: "Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ + % &"
     MinLength: 8
     MaxLength: 128
     NoEcho: true

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -341,7 +341,7 @@ Parameters:
     Default: '6.13.10'
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))'
     ConstraintDescription: "Must be a valid Confluence version number, for example 6.13.2. Find valid versions at https://confluence.atlassian.com/display/DOC/Confluence+Release+Notes"
-    Description: The version of Confluence to install.
+    Description: The version of Confluence to install
     Type: String
   CustomDnsName:
     Default: ''
@@ -390,7 +390,7 @@ Parameters:
       - db.t2.large
       - db.t2.xlarge
       - db.t2.2xlarge
-    ConstraintDescription: Must be a valid RDS instance class from the list
+    ConstraintDescription: Must be a valid RDS instance class from the list.
     Description: RDS instance type (must be R4 family if using Amazon Aurora).
     Type: String
   DBIops:
@@ -412,15 +412,15 @@ Parameters:
     Type: String
   DBMultiAZ:
     Description: When DBEngine is 'PostgreSQL', this will determine whether to provision a multi-AZ RDS instance. When DBEngine is 'Amazon Aurora PostgreSQL', this will determine whether to provision a single or a multiple-node Amazon Aurora cluster.
-    Default: true
+    Default: "true"
     AllowedValues:
-      - true
-      - false
+      - "true"
+      - "false"
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
   DBPassword:
     AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
-    ConstraintDescription: "Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ ) \" ') symbol"
+    ConstraintDescription: "Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol"
     Description: "Password for the user account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol."
     MinLength: 8
     MaxLength: 128
@@ -429,25 +429,28 @@ Parameters:
   DBPoolMaxSize:
     Default: 60
     Description: The maximum number of database connections that can be opened at any time. See https://confluence.atlassian.com/doc/performance-tuning-130289.html for reference on tuning database parameters.
-    Type: String
+    Type: Number
   DBPoolMinSize:
     Default: 20
     Description: The minimum number of idle database connections that are kept open at any time.
-    Type: String
+    Type: Number
   DBTimeout:
     Default: 30
-    Description: Seconds a connection can remain pooled but unused before being discarded. Zero means idle connections never expire.
-    Type: String
+    Description: Number of seconds that Connections in excess of minPoolSize should be permitted to remain idle in the pool before being culled.
+    Type: Number
   DBIdleTestPeriod:
     Default: 100
     Description: If greater than 0, this is the frequency (in seconds) that c3po will test all idle, pooled but unchecked-out connections.
-    Type: String
+    Type: Number
   DBMaxStatements:
     Default: 0
     Description: "The size of c3p0's global PreparedStatement cache. It controls the total number of statements cached, for all connections. If set, it should be a fairly large number, as each pooled Connection requires its own, distinct flock of cached statements."
-    Type: String
+    Type: Number
   DBValidate:
-    Default: false
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
     Description: If true, a connection test will be performed at every connection checkout to verify that the connection is valid.
     Type: String
   DBPreferredTestQuery:
@@ -457,16 +460,16 @@ Parameters:
   DBAcquireIncrement:
     Default: 1
     Description: Determines how many connections at a time c3p0 will try to acquire when the pool is exhausted.
-    Type: String
+    Type: Number
   DBStorage:
     Default: 200
     Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144. Not used for Amazon Aurora.
     Type: Number
   DBStorageEncrypted:
-    Default: false
+    Default: "false"
     AllowedValues:
-      - true
-      - false
+      - "true"
+      - "false"
     Description: Whether or not to encrypt the database.
     Type: String
   DBStorageType:
@@ -480,7 +483,7 @@ Parameters:
   DeploymentAutomationRepository:
     Default: 'https://bitbucket.org/atlassian/dc-deployments-automation.git'
     Type: String
-    Description: The deployment automation repository to use for per-node initialisation. Leave this as default unless you have customizations.
+    Description: The deployment automation repository to use for per-node initialization. Leave this as default unless you have customizations.
   DeploymentAutomationBranch:
     Default: "master"
     Type: String
@@ -500,7 +503,7 @@ Parameters:
   ExportPrefix:
     Default: 'ATL-'
     Description:
-      Each Atlassian Standard Infrastructure (ASI) uses a unique identifier. If you have multiple ASIs within the same AWS region, use this field to specify where to deploy Confluence.
+      Identifier used in all variables exported from this deployment’s Atlassian Standard Infrastructure (VPCID, SubnetIDs, KeyName). Use different identifier to deploy multiple Atlassian Standard Infrastructures in the same AWS region.
     Type: String
   HostedZone:
     Default: ''
@@ -508,8 +511,8 @@ Parameters:
     Description: (Optional) The domain name of the Amazon Route 53 PRIVATE Hosted Zone in which to create cnames.
     Type: String
   InternetFacingLoadBalancer:
-    Default: true
-    AllowedValues: [true, false]
+    Default: "true"
+    AllowedValues: ["true", "false"]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String
@@ -519,19 +522,19 @@ Parameters:
     Type: String
   JvmHeapOverrideSynchrony:
     Default: ''
-    Description: The heap size to use, in MB (e.g., 1024m) or GB (e.g., 1g), to override the default amount of memory to allocate to the JVM for your instance type.
+    Description: The heap size to use, in MiB (e.g., 1024m) or GiB (e.g., 1g), to override the default amount of memory to allocate to the JVM for Synchrony.
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
-    Type: String
+    Description: The EC2 Key Pair to allow SSH access to the instances.
+    Type: AWS::EC2::KeyPair::KeyName
     Default: ''
   MailEnabled:
     AllowedValues:
-      - true
-      - false
+      - "true"
+      - "false"
     ConstraintDescription: Must be 'true' or 'false'.
-    Default: true
+    Default: "true"
     Description: Enable mail processing and sending.
     Type: String
   SubDomainName:
@@ -540,11 +543,10 @@ Parameters:
     Type: String
   SSLCertificateARN:
     Default: ''
-    Description: Amazon Resource Name (ARN) of your SSL certificate. If you want to use your own certificate that you generated outside of Amazon, you need to first import it to AWS Certificate Manager. After a successful import, you'll receive the ARN. If you want to create a certificate with AWS Certificate Manager (ACM certificate), you will receive the ARN after it's successfully created.
+    Description: "Amazon Resource Name (ARN) of your SSL certificate. If you want to use your own certificate that you generated outside of Amazon, you need to first import it to AWS Certificate Manager. After a successful import, you'll receive the ARN. If you want to create a certificate with AWS Certificate Manager (ACM certificate), you will receive the ARN after it's successfully created."
     MinLength: 0
     MaxLength: 90
     Type: String
-
   SynchronyClusterNodeMax:
     Description: Maximum number of Synchrony cluster nodes.
     Default: 1
@@ -652,11 +654,11 @@ Parameters:
   TomcatAcceptCount:
     Default: 10
     Description: The maximum queue length for incoming connection requests when all possible request processing threads are in use.
-    Type: String
+    Type: Number
   TomcatConnectionTimeout:
     Default: 20000
     Description: The number of milliseconds this connector will wait, after accepting a connection, for the request URI line to be presented.
-    Type: String
+    Type: Number
   TomcatContextPath:
     Default: ''
     AllowedPattern: '^(\/[A-z_\-0-9\.]+)?$'
@@ -665,19 +667,22 @@ Parameters:
   TomcatDefaultConnectorPort:
     Default: 8080
     Description: The port on which to serve the application.
-    Type: String
+    Type: Number
   TomcatEnableLookups:
-    Default: false
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
     Description: Set to true if you want calls to request.getRemoteHost() to perform DNS lookups in order to return the actual host name of the remote client.
     Type: String
   TomcatMaxThreads:
     Default: 48
     Description: The maximum number of request processing threads to be created by this connector, which therefore determines the maximum number of simultaneous requests that can be handled.
-    Type: String
+    Type: Number
   TomcatMinSpareThreads:
     Default: 10
     Description: The minimum number of threads always kept running.
-    Type: String
+    Type: Number
   TomcatProtocol:
     Default: 'HTTP/1.1'
     Description: Sets the protocol to handle incoming traffic.
@@ -685,7 +690,7 @@ Parameters:
   TomcatRedirectPort:
     Default: 8443
     Description: The port number for Catalina to use when automatically redirecting a non-SSL connector actioning a redirect to a SSL URI.
-    Type: String
+    Type: Number
   QSS3BucketName:
     Default: 'aws-quickstart'
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$


### PR DESCRIPTION
[Documentation ticket](https://bulldog.internal.atlassian.com/browse/DCD-1008)


See the Crowd PR below for the basis of these changes including relevant discussion:

atlassian/quickstart-atlassian-crowd#26

**Passing on branch CI plan**
https://server-syd-bamboo.internal.atlassian.com/browse/DCD-AWSCONFLUENCE50-DEPLOY-1