### PR TITLE
Update CI runs to not use bastion host

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ You need to create the required AWS networking infrastructure
 (VPC, subnets) by using the [ASI Quick Start](https://fwd.aws/xYyYy), or by deploying Confluence with a new ASI.
 For details, see the [deployment guide](https://fwd.aws/kBpWN).
 
+## Deploying for production
+
+For production deployments, avoid launching the Confluence Quick Start from the AWS Quick Start interface. If you do, any changes made to the Quick Start templates will propagate directly to your deployment. These updates sometimes introduce unexpected changes that could break your deployment.
+
+Instead, clone the Confluence Quick Start templates to a custom Amazon Simple Storage Service (Amazon S3) bucket. Then, launch the templates directly from the S3 bucket. This practice lets you control when to apply the latest changes to your environment. See [Launching from a cloned Quick Start (recommended for production)
+](https://confluence.atlassian.com/x/dRBzN#RunningConfluenceDataCenterinAWS-s3bucketcustom) for instructions.
+
+
 ## Development notes
 
 ### Pre-commit hook

--- a/ci/params/aurora/quickstart-confluence-dc-aurora-params.json
+++ b/ci/params/aurora/quickstart-confluence-dc-aurora-params.json
@@ -34,5 +34,9 @@
   {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
+  },
+  {
+    "ParameterKey": "BastionHostRequired",
+    "ParameterValue": "false"
   }
 ]

--- a/ci/params/default/quickstart-confluence-default.json
+++ b/ci/params/default/quickstart-confluence-default.json
@@ -34,5 +34,9 @@
   {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
+  },
+  {
+    "ParameterKey": "BastionHostRequired",
+    "ParameterValue": "false"
   }
 ]

--- a/ci/params/ssl-and-dns/quickstart-confluence-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-confluence-ci-params.json
@@ -54,5 +54,9 @@
     {
         "ParameterKey": "QSS3KeyPrefix",
         "ParameterValue": "quickstart-atlassian-confluence/"
+    },
+    {
+        "ParameterKey": "BastionHostRequired",
+        "ParameterValue": "false"
     }
 ]

--- a/ci/quickstart-confluence-master-parms.json
+++ b/ci/quickstart-confluence-master-parms.json
@@ -50,5 +50,9 @@
   {
     "ParameterKey": "CollaborativeEditingMode",
     "ParameterValue": "synchrony-separate-nodes"
+  },
+  {
+    "ParameterKey": "BastionHostRequired",
+    "ParameterValue": "false"
   }
 ]


### PR DESCRIPTION
We have changed our CI configurations so that they don't use a bastion host. The bastion host increases the attack surface of the deployment which is not necessary for test runs.

No customer impact from this change, just want to keep our fork up to date with the upstream

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
