### PR TITLE
DCD-1231: Enable Postgres 11 as an option as it is now supported in Confluence 7.12

### DIFF
--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -332,7 +332,7 @@ Parameters:
     Description: Collaborative Editing can be off, run locally on the Confluence nodes (requires Confluence version 6.12+ and 1 GB heap free for Synchrony), or run on a separately autoscaled group of nodes.
     Type: String
   ConfluenceVersion:
-    Default: '7.4.3'
+    Default: '7.4.8'
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))'
     ConstraintDescription: "Must be a valid Confluence version number, for example 6.13.2. Find valid versions at https://confluence.atlassian.com/display/DOC/Confluence+Release+Notes"
     Description: The version of Confluence to install
@@ -354,6 +354,7 @@ Parameters:
     AllowedValues:
       - 9
       - 10
+      - 11
     Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected."
     Type: String
   DBInstanceClass:

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -344,7 +344,7 @@ Parameters:
     Description: Collaborative Editing can be off, run locally on the Confluence nodes (requires Confluence version 6.12+ and 1 GB heap free for Synchrony), or run on a separately autoscaled group of nodes.
     Type: String
   ConfluenceVersion:
-    Default: '7.4.3'
+    Default: '7.4.8'
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))'
     ConstraintDescription: "Must be a valid Confluence version number, for example 6.13.2. Find valid versions at https://confluence.atlassian.com/display/DOC/Confluence+Release+Notes"
     Description: The version of Confluence to install
@@ -366,6 +366,7 @@ Parameters:
     AllowedValues:
       - 9
       - 10
+      - 11
     Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected."
     Type: String
   DBInstanceClass:
@@ -1163,10 +1164,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: fc08aac3b7c33646e6db6085460fc7cd3506d8e8"
+          Value: "COMMIT: ec423a0e5112e03efd4c9319b47a8bbde1f45dd8"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-10T05:02:45Z"
+          Value: "TIMESTAMP: 2021-04-20T00:41:29Z"
           PropagateAtLaunch: true
 
   ClusterNodeLaunchConfig:
@@ -1612,9 +1613,9 @@ Resources:
           Value: !Ref AWS::StackId
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: fc08aac3b7c33646e6db6085460fc7cd3506d8e8"
+          Value: "COMMIT: ec423a0e5112e03efd4c9319b47a8bbde1f45dd8"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-10T05:02:45Z"
+          Value: "TIMESTAMP: 2021-04-20T00:41:29Z"
   EFSMountAz1:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -1699,9 +1700,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: fc08aac3b7c33646e6db6085460fc7cd3506d8e8"
+          Value: "COMMIT: ec423a0e5112e03efd4c9319b47a8bbde1f45dd8"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-10T05:02:45Z"
+          Value: "TIMESTAMP: 2021-04-20T00:41:29Z"
   LoadBalancerHTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -1784,9 +1785,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: fc08aac3b7c33646e6db6085460fc7cd3506d8e8"
+          Value: "COMMIT: ec423a0e5112e03efd4c9319b47a8bbde1f45dd8"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-10T05:02:45Z"
+          Value: "TIMESTAMP: 2021-04-20T00:41:29Z"
     DependsOn:
       - LoadBalancer
   SynchronyTargetGroup:
@@ -1894,9 +1895,9 @@ Resources:
           Value: !Join [' ', [!Ref "AWS::StackName", 'sg']]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: fc08aac3b7c33646e6db6085460fc7cd3506d8e8"
+          Value: "COMMIT: ec423a0e5112e03efd4c9319b47a8bbde1f45dd8"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-10T05:02:45Z"
+          Value: "TIMESTAMP: 2021-04-20T00:41:29Z"
       VpcId:
         Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
   SecurityGroupIngress:


### PR DESCRIPTION
Tested with RDS Psql 11 and Aurora Psql 11.
