### PR TITLE
DCD-1354 Eliminate unused KMS actions on AWS Quickstart

### DIFF
--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -1934,56 +1934,21 @@ Resources:
               AWS:
                 - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
             Action:
-              - kms:CancelKeyDeletion
-              - kms:ConnectCustomKeyStore
               - kms:CreateAlias
-              - kms:CreateCustomKeyStore
               - kms:CreateGrant
               - kms:CreateKey
-              - kms:Decrypt
               - kms:DeleteAlias
-              - kms:DeleteCustomKeyStore
               - kms:DeleteImportedKeyMaterial
-              - kms:DescribeCustomKeyStores
               - kms:DescribeKey
               - kms:DisableKey
               - kms:DisableKeyRotation
-              - kms:DisconnectCustomKeyStore
               - kms:EnableKey
               - kms:EnableKeyRotation
-              - kms:Encrypt
-              - kms:GenerateDataKey
-              - kms:GenerateDataKeyPair
-              - kms:GenerateDataKeyPairWithoutPlaintext
-              - kms:GenerateDataKeyWithoutPlaintext
-              - kms:GenerateRandom
               - kms:GetKeyPolicy
               - kms:GetKeyRotationStatus
               - kms:GetParametersForImport
               - kms:GetPublicKey
-              - kms:ImportKeyMaterial
-              - kms:ListAliases
-              - kms:ListGrants
-              - kms:ListKeyPolicies
-              - kms:ListKeys
-              - kms:ListResourceTags
-              - kms:ListRetirableGrants
               - kms:PutKeyPolicy
-              - kms:ReEncryptFrom
-              - kms:ReEncryptTo
-              - kms:ReplicateKey
-              - kms:RetireGrant
-              - kms:RevokeGrant
-              - kms:ScheduleKeyDeletion
-              - kms:Sign
-              - kms:SynchronizeMultiRegionKey
-              - kms:TagResource
-              - kms:UntagResource
-              - kms:UpdateAlias
-              - kms:UpdateCustomKeyStore
-              - kms:UpdateKeyDescription
-              - kms:UpdatePrimaryRegion
-              - kms:Verify
             Resource: '*'
       EnableKeyRotation: true
       Tags:


### PR DESCRIPTION
*DCD-1354*

Eliminate unused KMS actions on AWS Quickstart.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.