### PR TITLE
DCD-1333 Disable keypairs for Taskcat CI builds

### DIFF
--- a/ci/params/aurora/quickstart-confluence-dc-aurora-params.json
+++ b/ci/params/aurora/quickstart-confluence-dc-aurora-params.json
@@ -32,10 +32,6 @@
     "ParameterValue": "quickstart-atlassian-confluence/"
   },
   {
-    "ParameterKey": "KeyPairName",
-    "ParameterValue": "replaced-by-taskcat-override-file"
-  },
-  {
     "ParameterKey": "BastionHostRequired",
     "ParameterValue": "false"
   }

--- a/ci/params/default/quickstart-confluence-default.json
+++ b/ci/params/default/quickstart-confluence-default.json
@@ -32,10 +32,6 @@
     "ParameterValue": "quickstart-atlassian-confluence/"
   },
   {
-    "ParameterKey": "KeyPairName",
-    "ParameterValue": "replaced-by-taskcat-override-file"
-  },
-  {
     "ParameterKey": "BastionHostRequired",
     "ParameterValue": "false"
   }

--- a/ci/params/ssl-and-dns/quickstart-confluence-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-confluence-ci-params.json
@@ -24,10 +24,6 @@
         "ParameterValue": "Provisioned IOPS"
     },
     {
-        "ParameterKey": "KeyPairName",
-        "ParameterValue": "replaced-by-taskcat-override-file"
-    },
-    {
         "ParameterKey": "CidrBlock",
         "ParameterValue": "0.0.0.0/0"
     },

--- a/ci/quickstart-confluence-master-parms.json
+++ b/ci/quickstart-confluence-master-parms.json
@@ -40,10 +40,6 @@
     "ParameterValue": "quickstart-atlassian-confluence/"
   },
   {
-    "ParameterKey": "KeyPairName",
-    "ParameterValue": "replaced-by-taskcat-override-file"
-  },
-  {
     "ParameterKey": "ExportPrefix",
     "ParameterValue": "$[taskcat_random-string]"
   },


### PR DESCRIPTION
*DCD-1333*

*Disable keypairs for Taskcat CI builds.*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.